### PR TITLE
Remove the github paragraph on header

### DIFF
--- a/DOCUMENTATION/themes/hugo-material-docs/layouts/partials/header.html
+++ b/DOCUMENTATION/themes/hugo-material-docs/layouts/partials/header.html
@@ -21,7 +21,6 @@
     <div class="button button-github" role="button" aria-label="GitHub">
         <a style="padding: 0px; font-size:40px" href="https://github.com/{{ . }}" title="@{{ . }} on GitHub" target="_blank" class="toggle-button icon icon-github"></a>
     </div>
-      <p style="font-size: 18px; padding: 8px">Github</p>
     {{ end }}
     
     <!-- TODO: disabled until Hugo supports the generation of a content index natively 


### PR DESCRIPTION
Remove the github paragraph on header, since it already has a link to github using aria to accessibility

<!--- Thank you for contributing to Laradock -->

##### I completed the 3 steps below:

- [X] I've read the [Contribution Guide](http://laradock.io/contributing).
- [X] I've updated the **documentation**. (refer to [this](http://laradock.io/contributing/#update-the-documentation-site) for how to do so).
- [X] I enjoyed my time contributing and making developer's life easier :)
